### PR TITLE
Fix getFullMissionData for pending edited missions

### DIFF
--- a/IMATTC.user.js
+++ b/IMATTC.user.js
@@ -399,7 +399,7 @@ function init() {
           var mId = mission.mission_guid;
           missionPromises.push($http.post(window.origin + "/api/author/getMissionForProfile", {mission_guid: mId}));
         } else {
-          var mId = mission.draft_mission_id;
+          var mId = mission.draft_mission_id || mission.submitted_mission_id;
           missionPromises.push($http.post(window.origin + "/api/author/getMission", {mission_id: mId}));
         }
       });


### PR DESCRIPTION
Not sure if this is the best way to do this, but when I had a mission of a set with a pending edit. The Preview Route function was broken. Tracked the issue back to an undefined draft_mission_id on the object. 